### PR TITLE
removed banner match

### DIFF
--- a/filter.txt
+++ b/filter.txt
@@ -64,7 +64,6 @@
 ##[id^="ads_bottom"]
 ##[id^="adtube-"]
 ##[id^="apanet_ads"]
-##[id^="banner"]
 ##[id^="faradars"]
 ##[id^="mediaad-"]
 ##[id^="ml-webforms-popup"]


### PR DESCRIPTION
It disrupts functionality or changes appereance in a number of websites and I think It is too general to be useful.
examples:
http://ngmodem.com/najmtour/مودم نجم.html
https://gchq.github.io/CyberChef/