### PR TITLE
add poparya.com

### DIFF
--- a/filter.txt
+++ b/filter.txt
@@ -1041,6 +1041,7 @@ zoomtech.ir###text-3
 ||pic.beautyhome.ir/*.gif
 ||picofile.com/file/*/*.gif
 ||pishkhaan.net/pishkhaanads/$image
+||poparya.com^
 ||popbox.skinak.ir^
 ||popmaster.ir/pop.php
 ||popupha.com^


### PR DESCRIPTION
This domain name (i.e. `poparya.com`) is used in conjunction with popups within `www.downloadha.com`.

Here's an excerpt found on `www.downloadha.com`:
```html
<script type="text/javascript">var poparya_user_id = 593;var poparya_userMax = 1;</script>
<script type="text/javascript" src="https://poparya.com/website/js"></script>
```

I added the while domain so PiHole and DNSCrypt users myself can import it as a hosts file.