### PR TITLE
feat: add adv elements on asriran [dot] com

### DIFF
--- a/filter.txt
+++ b/filter.txt
@@ -1282,6 +1282,7 @@ zoomtech.ir###text-3
 ||subtitlepedia.biz/images/banners/$image
 ||t3l.ir^$popup
 ||tableaumag.com/wp-content/uploads/sites/*/*banner
+||tabnak.ir/*/adv/
 ||taknaz.net/taknaz/pish2.php$subdocument
 ||taknaz.net/taknaz/test.php$subdocument
 ||taknaz.net/up/


### PR DESCRIPTION
asriran [dot] com uses some new own ads elements which have element ids like: `adv<X>`  that `X` is a number